### PR TITLE
Backend check if portal user is authorized to download PDF financial overview.

### DIFF
--- a/app/Http/Controllers/Portal/FinancialOverview/FinancialOverviewContactController.php
+++ b/app/Http/Controllers/Portal/FinancialOverview/FinancialOverviewContactController.php
@@ -5,12 +5,23 @@ namespace App\Http\Controllers\Portal\FinancialOverview;
 use App\Eco\FinancialOverview\FinancialOverviewContact;
 use App\Helpers\FinancialOverview\FinancialOverviewHelper;
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 
 class FinancialOverviewContactController extends Controller
 {
     public function download(FinancialOverviewContact $financialOverviewContact)
     {
+        $portalUser = Auth::user();
+        if (!Auth::isPortalUser() || !$portalUser->contact) {
+            abort(501, 'Er is helaas een fout opgetreden.');
+        }
+        $allowedContactIds = $portalUser->contact->occupations->pluck('primary_contact_id')->toArray();
+        $authorizedForContact = in_array($financialOverviewContact->contact_id, $allowedContactIds);
+        if ($portalUser->contact_id != $financialOverviewContact->contact_id && !$authorizedForContact) {
+            abort(403, 'Verboden');
+        }
+
         if ($financialOverviewContact->filename) {
             $filePath = Storage::disk('administrations')->getDriver()
                 ->getAdapter()->applyPathPrefix($financialOverviewContact->filename);


### PR DESCRIPTION
Only allowed are financial overviews where contact relation is the same als the contact relation of portal user who requested the download or the contacts (through occupations) where the contact is linked to as primary contact.